### PR TITLE
Update team statistics on drag and drop model change

### DIFF
--- a/src/app/dashboard/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard/dashboard.component.html
@@ -83,9 +83,9 @@
       </div>
     </div>
     <div
-      [dragula]="'first-bag'"
+      dragula="persons"
       class="flex-row person-pool-preview-row flex-wrap flex-grow"
-      [dragulaModel]="teamService.personsWithoutTeam">
+      [(dragulaModel)]="teamService.personsWithoutTeam">
       <app-person-preview
         *ngFor="let person of teamService.personsWithoutTeam"
         [person]="person"

--- a/src/app/dashboard/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard/dashboard.component.ts
@@ -37,7 +37,7 @@ export class DashboardComponent implements OnInit {
     private overlayService: OverlayService
   ) {
     /* save model when modified by drag&drop operation */
-    dragulaService.dropModel('"first-bag"').subscribe(({ el, target, source, sourceModel, targetModel, item }) => {
+    dragulaService.dropModel("persons").subscribe(({ el, target, source, sourceModel, targetModel, item }) => {
       teamService.saveToLocalBrowserStorage();
     });
   }

--- a/src/app/dashboard/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard/dashboard.component.ts
@@ -39,8 +39,16 @@ export class DashboardComponent implements OnInit {
   ) {
     /* save model when modified by drag & drop operation */
     dragulaService.dropModel("persons").subscribe(({ el, target, source, sourceModel, targetModel, item }) => {
-      let person:Person = item
-      person.team = this.inferTeam(targetModel, person)
+      let person: Person = teamService.getPersonById(item.tumId)
+      let currentTeam = person.team
+      currentTeam.remove(person)
+
+      let inferredNewTeam = this.inferTeam(targetModel, person)
+
+      // just in case the team inferred from student references is also a copy and
+      // not stored in the TeamService -> match by name (worst case this returns the same reference again)
+      let newTeam = teamService.getTeamByName(inferredNewTeam.name)
+      newTeam.add(person)
       teamService.saveToLocalBrowserStorage()
     });
   }

--- a/src/app/dashboard/team/team.component.html
+++ b/src/app/dashboard/team/team.component.html
@@ -27,7 +27,7 @@
         <div>Drag persons here</div>
       </div>
     </div>
-    <div [dragula]="'first-bag'" class="drag-container" [dragulaModel]="team.persons">
+    <div dragula="persons" class="drag-container" [(dragulaModel)]="team.persons">
       <app-person-preview
         *ngFor="let person of team.persons"
         [person]="person"

--- a/src/app/shared/layers/business-logic-layer/team.service.ts
+++ b/src/app/shared/layers/business-logic-layer/team.service.ts
@@ -24,6 +24,14 @@ export class TeamService {
     this.updateDerivedProperties();
   }
 
+  public getTeamByName(teamName: string): Team {
+    return this.teams.find(team => team.name === teamName) // assumes multiple teams do not exist with the same name
+  }
+
+  public getPersonById(tumId: string): Person {
+    return this.persons.find(person => person.tumId == tumId) // assumes multiple people do not exist with same TUM id
+  }
+
   public updateDerivedProperties() {
     this.personsWithoutTeam = this.persons.filter(person => person.team === null);
   }


### PR DESCRIPTION
v2 of Dragula came with some breaking changes, one of which was that the [dragulaModel] directive no longer mutates the array that you provide it but instead returns a shallow copy of the result, to actually change/update the array (for example a team) a simple switch to the two-way binding alternative [(dragulaModel)] can be used.

Now dragging a person from one team to another or to the unassigned person pool automagically updates the team statistics (I love frontend frameworks!), so the team size and priority distribution show the correct values, and any unsatisfied constraints are highlighted in red.

What changed: Dragging and dropping a person from one team to another to manually modify the allocation now correctly updates the model to reflect a person's new team

Why the change: Without the model update manual changes don't persist -> CSV export (for example) doesn't correctly reflect the teams persons were assigned in final allocation

Testing steps: Import & load example data -> Drag and drop a student from one team to another -> Export team allocation data and check whether the column specifying the person's team matches the team the person was dragged into