### PR TITLE
Enhancement: Change build process and deployment to reduce docker image size

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -43,13 +43,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "200kb",
+                  "maximumError": "400kb"
                 }
               ],
               "optimization": {

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,20 @@
+server {
+  listen 80;
+  sendfile on;
+  default_type application/octet-stream;
+
+  gzip on;
+  gzip_http_version 1.1;
+  gzip_disable      "MSIE [1-6]\.";
+  gzip_min_length   256;
+  gzip_vary         on;
+  gzip_proxied      expired no-cache no-store private auth;
+  gzip_types        text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_comp_level   9;
+
+  root /usr/share/nginx/html;
+
+  location / {
+    try_files $uri $uri/ /index.html =404;
+  }
+}


### PR DESCRIPTION
What changed: Instead of saving the npm dependencies in the docker image, the new `Dockerfile` uses two stages, where the first stage has a node image compile the output and the second stage takes these these bundled files (without the dependencies) and serves them via an image that has an nginx server, thus the dependencies are no longer included in the final image. This effectively reduces the size of the image by an order of magnitude.

Why the changes: A smaller image size (especially for such a relatively small codebase) is always of advantage since it takes up less storage space etc., a side effect of this is also that the startup time is a *lot* shorter (AFAIK the `webpack-dev-server` did some work at startup whereas the nginx server can immediately start serving the compiled output, startup time should therefore be almost negligible now).

Testing steps: Download the package that was built with a version of the repository that has the changes of this PR applied, start the container with the instructions from the README, confirm that the startup time is almost non-existent as TEASE should be immediately accessible via the `localhost` URL after starting the container. Confirm that the size of the image is around 150MB (instead of the previously ~1-2 GB).
