### PR TITLE
Switch to native fonts and host material design icons locally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "html2canvas": "^1.4.1",
         "javascript-lp-solver": "^0.4.24",
         "jszip": "^3.10.1",
+        "material-icons": "^1.13.6",
         "ng2-charts": "^4.1.1",
         "ng2-dragula": "^3.2.0",
         "papaparse": "^5.4.0",
@@ -10724,6 +10725,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/material-icons": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/material-icons/-/material-icons-1.13.6.tgz",
+      "integrity": "sha512-I9NjTMwdmq7QECY92ReLqbhWtUZmjlE0eX9UbIHFsSbT7wRp3aj/3ZbuHLFb9w96HG0S4pWbVQjwTQLxyfYyEg=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "html2canvas": "^1.4.1",
     "javascript-lp-solver": "^0.4.24",
     "jszip": "^3.10.1",
+    "material-icons": "^1.13.6",
     "ng2-charts": "^4.1.1",
     "ng2-dragula": "^3.2.0",
     "papaparse": "^5.4.0",

--- a/src/index.html
+++ b/src/index.html
@@ -2,13 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Tease</title>
+    <title>TEASE</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="assets/images/iconsmall.png" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
   </head>
   <body class="mat-typography">
     <app-root></app-root>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -35,8 +35,9 @@ $tease-theme: mat.define-light-theme((
 
 /* You can add global styles to this file, and also import other style files */
 
+@import 'material-icons/iconfont/material-icons.css';
+
 html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
 /* Importing Bootstrap SCSS file. */
 @import 'bootstrap/scss/bootstrap';


### PR DESCRIPTION
What changed: For privacy related reasons we've stopped using google fonts and switched to native fonts for the TEASE UI. The material icons used are also stored inside font files, therefore instead of accessing these by linking to the web font hosted on Google Fonts, the project now stores them locally using the [`material-icons`](https://github.com/marella/material-icons) package.

Why the changes: Privacy related reasons and so that TEASE can run completely offline.

Testing steps: Just to be safe, clear the cache to remove stored fonts and possibly also turn off your internet connection temporarily to make sure no missed fonts are still downloaded (in case some fonts were missed). Start TEASE and import the example data, confirm that the text still displays fine and that the material icons are also rendering in the buttons.