### PR TITLE
Improve button look and feel and increase spacing between icons and button text

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -28,7 +28,7 @@
   <div class="buttons-overlay flex-row-reverse pointer-events-none">
     <div class="buttons-overlay-item pointer-events-auto">
       <button
-        md-raised-button
+        mat-raised-button
         color="primary"
         (click)="
           onTeamStatisticsButtonPressed.emit(toggleTeamStatisticsButtonState);
@@ -43,7 +43,7 @@
     </div>
 
     <div class="buttons-overlay-item pointer-events-auto">
-      <button md-raised-button color="primary" (click)="showExportOverlay()">
+      <button mat-raised-button color="primary" (click)="showExportOverlay()">
         <div class="flex-row flex-center">
           <mat-icon class="material-icon-trailing-space">file_download</mat-icon>
           <div>Export</div>
@@ -52,7 +52,7 @@
     </div>
 
     <div class="buttons-overlay-item pointer-events-auto">
-      <button md-raised-button color="primary" (click)="showResetTeamAllocationConfirmation()">
+      <button mat-raised-button color="primary" (click)="showResetTeamAllocationConfirmation()">
         <div class="flex-row flex-center">
           <mat-icon class="material-icon-trailing-space">replay</mat-icon>
           <div>Reset</div>
@@ -61,7 +61,7 @@
     </div>
 
     <div class="buttons-overlay-item pointer-events-auto">
-      <button md-raised-button color="primary" (click)="showSortConfirmation()">
+      <button mat-raised-button color="primary" (click)="showSortConfirmation()">
         <div class="flex-row flex-center">
           <mat-icon class="material-icon-trailing-space">sort</mat-icon>
           <div>Sort</div>
@@ -70,7 +70,7 @@
     </div>
 
     <div class="buttons-overlay-item pointer-events-auto">
-      <button md-raised-button color="primary" (click)="showImportOverlay()">
+      <button mat-raised-button color="primary" (click)="showImportOverlay()">
         <div class="flex-row flex-center">
           <mat-icon class="material-icon-trailing-space">file_upload</mat-icon>
           <div>Import</div>

--- a/src/app/dashboard/confirmation-overlay/confirmation-overlay.component.html
+++ b/src/app/dashboard/confirmation-overlay/confirmation-overlay.component.html
@@ -10,9 +10,9 @@
       </div>
     </div>
     <div class="dialog-footer flex-row flex-center flex-no-shrink">
-      <button md-raised-button color="primary" (click)="data.onCancelled()">Cancel</button>
+      <button mat-raised-button color="primary" (click)="data.onCancelled()">Cancel</button>
       <div class="flex-grow"></div>
-      <button md-raised-button color="warn" (click)="data.onConfirmed()">
+      <button mat-raised-button color="warn" (click)="data.onConfirmed()">
         {{ data.action }}
       </button>
     </div>

--- a/src/app/dashboard/constraints-overlay/constraints-overlay.component.html
+++ b/src/app/dashboard/constraints-overlay/constraints-overlay.component.html
@@ -42,7 +42,7 @@
 
     <div class="dialog-footer flex-row-reverse flex-center flex-no-shrink">
       <button
-        md-raised-button
+        mat-raised-button
         color="primary"
         [disabled]="hasWarnings()"
         (click)="applyConstraints(); $event.stopPropagation()">

--- a/src/app/dashboard/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard/dashboard.component.html
@@ -30,7 +30,7 @@
     <div class="flex-grow"></div>
 
     <button
-      md-raised-button
+      mat-raised-button
       color="primary"
       class="distribute-button flex-no-shrink"
       (click)="togglePersonPoolStatistics()">
@@ -39,7 +39,7 @@
         <div>{{ statisticsVisible ? 'Hide' : 'Show' }} Statistics</div>
       </div>
     </button>
-    <button md-raised-button color="primary" class="distribute-button flex-no-shrink" (click)="openConstraintsDialog()">
+    <button mat-raised-button color="primary" class="distribute-button flex-no-shrink" (click)="openConstraintsDialog()">
       <div class="flex-row flex-center distribute-button-row">
         <mat-icon class="flex-spacing-x-2px material-icon-trailing-space">build</mat-icon>
         <div>Distribute With Constraints</div>

--- a/src/app/dashboard/export-overlay/export-overlay.component.html
+++ b/src/app/dashboard/export-overlay/export-overlay.component.html
@@ -16,7 +16,7 @@
             This exports the current team allocation as CSV file that you can use to backup and share the current
             project. Additionally, a text file containing a history of constraint applications is provided.
           </div>
-          <button md-raised-button color="primary" (click)="exportCSV()">
+          <button mat-raised-button color="primary" (click)="exportCSV()">
             <mat-icon>get_app</mat-icon>Download Archive
           </button>
         </div>
@@ -37,7 +37,7 @@
             [class.progress-bar-disabled]="!imageExportRunning"
             mode="determinate"
             [value]="getImageExportProgressPercentage()"></mat-progress-bar>
-          <button md-raised-button color="primary" [disabled]="imageExportRunning" (click)="exportScreenshots()">
+          <button mat-raised-button color="primary" [disabled]="imageExportRunning" (click)="exportScreenshots()">
             <mat-icon>get_app</mat-icon>Download Archive
           </button>
         </div>

--- a/src/app/dashboard/import-overlay/import-overlay.component.html
+++ b/src/app/dashboard/import-overlay/import-overlay.component.html
@@ -20,7 +20,7 @@
       <div class="flex-grow flex-column flex-basis-zero alternative-box flex-spacing-10">
         <div class="align-self-center alternative-heading">Example Data</div>
         <div>You can use example data to explore and test the app.</div>
-        <button md-raised-button color="primary" (click)="loadExampleData()">
+        <button mat-raised-button color="primary" (click)="loadExampleData()">
           <mat-icon>cloud_download</mat-icon>Load Example Data
         </button>
       </div>
@@ -28,7 +28,7 @@
       <div class="flex-grow flex-column flex-basis-zero alternative-box flex-spacing-10">
         <div class="align-self-center alternative-heading">CSV File</div>
         <div>Data can be loaded from a file in the CSV format.</div>
-        <button md-raised-button color="primary" (click)="openFileInput()">
+        <button mat-raised-button color="primary" (click)="openFileInput()">
           <mat-icon>insert_drive_file</mat-icon>Choose File
         </button>
       </div>

--- a/src/app/dashboard/intro-card/intro-card.component.html
+++ b/src/app/dashboard/intro-card/intro-card.component.html
@@ -2,7 +2,7 @@
   <div class="heading">Welcome to TEASE!</div>
   <div class="text-row flex-row flex-center">
     <div class="text">To get started, press</div>
-    <button md-raised-button color="primary" (click)="onImportPressed.emit()">
+    <button mat-raised-button color="primary" (click)="onImportPressed.emit()">
       <div class="flex-row flex-center">
         <mat-icon class="material-icon-trailing-space">file_upload</mat-icon>
         <div>Import</div>

--- a/src/app/dashboard/person-detail-overlay/person-detail-overlay.component.html
+++ b/src/app/dashboard/person-detail-overlay/person-detail-overlay.component.html
@@ -72,11 +72,11 @@
         <div class="flex-row flex-no-shrink">
           <button
             *ngIf="!isInTeam(data.person)"
-            md-raised-button
+            mat-raised-button
             color="primary"
             (click)="data.onPreviousPersonClicked(); $event.stopPropagation()">
             <div class="flex-row flex-center">
-              <div class="key-icon-container">
+              <div class="key-icon-container next-previous-person-buttons">
                 <mat-icon>keyboard_arrow_left</mat-icon>
               </div>
               <div>Previous Person</div>
@@ -85,11 +85,11 @@
           <div class="flex-grow"></div>
           <button
             *ngIf="!isInTeam(data.person)"
-            md-raised-button
+            mat-raised-button
             color="primary"
             (click)="data.onNextPersonClicked(); $event.stopPropagation()">
             <div class="flex-row flex-center">
-              <div class="key-icon-container">
+              <div class="key-icon-container next-previous-person-buttons">
                 <mat-icon>keyboard_arrow_right</mat-icon>
               </div>
               <div>Next Person</div>

--- a/src/app/dashboard/person-detail-overlay/person-detail-overlay.component.scss
+++ b/src/app/dashboard/person-detail-overlay/person-detail-overlay.component.scss
@@ -112,3 +112,7 @@ app-team {
   border: 1.5px solid rgba(0, 0, 0, 0.7);
   margin-right: 5px;
 }
+
+.next-previous-person-buttons {
+  border: none;
+}

--- a/src/app/dashboard/person-highlighting-overlay/person-highlighting-overlay.component.html
+++ b/src/app/dashboard/person-highlighting-overlay/person-highlighting-overlay.component.html
@@ -166,7 +166,7 @@
 
     <div class="dialog-footer flex-row flex-center flex-no-shrink">
       <div class="flex-grow flex-column"></div>
-      <button md-raised-button color="primary" (click)="save()">Save</button>
+      <button mat-raised-button color="primary" (click)="save()">Save</button>
     </div>
   </div>
 </div>

--- a/src/app/dashboard/person-preview/person-preview.component.scss
+++ b/src/app/dashboard/person-preview/person-preview.component.scss
@@ -6,6 +6,11 @@
 @include horizontal-spacing(spacing-3-x, 3px);
 @include vertical-spacing(spacing-3-y, 3px);
 
+// change box sizing back to 'border-box' for the preview cards
+* {
+  box-sizing: border-box;
+}
+
 .person-card {
   margin: 5px;
   color: black;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -36,11 +36,15 @@ $tease-theme: mat.define-light-theme((
 /* You can add global styles to this file, and also import other style files */
 
 @import 'material-icons/iconfont/material-icons.css';
-
 html, body { height: 100%; }
 
 /* Importing Bootstrap SCSS file. */
 @import 'bootstrap/scss/bootstrap';
+
+// change 'border-box' box sizing from bootstrap that is causing some buttons to render outside their container
+* {
+  box-sizing: content-box;
+}
 
 body {
   margin: 0;


### PR DESCRIPTION
What changed: The buttons in the application overall looked odd as changes to the material UI naming scheme meant the buttons were no longer being correctly styled. Made the necessary syntactic changes to have the buttons be styled again to look more in-line with the general style of the UI. Also increased the spacing slightly between button icons and their text/name.

Why the changes: The buttons looked out of place due to not being styled with the material UI stylesheets (as it was before the update to Angular 15). We always want to improve the look and feel of the UI to make using the app a more pleasant experience and avoid distracting details such as certain UI elements looking out of place.

Testing steps: Startup TEASE and confirm that the buttons now look more in line with the rest of the UI.