### PR TITLE
Bug: Wrong Pairing of Gravatar and Student after Exporting Card Images

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -20,8 +20,8 @@
   <!-- dashboard -->
   <div class="app-content position-fixed-fill">
     <app-dashboard
-      (onImportPressed)="showImportOverlay()"
-      [onTeamStatisticsButtonPressed]="onTeamStatisticsButtonPressed"></app-dashboard>
+      (importPressed)="showImportOverlay()"
+      [teamStatisticsButtonPressed]="teamStatisticsButtonPressed"></app-dashboard>
   </div>
 
   <!-- buttons overlay -->
@@ -31,7 +31,7 @@
         mat-raised-button
         color="primary"
         (click)="
-          onTeamStatisticsButtonPressed.emit(toggleTeamStatisticsButtonState);
+          teamStatisticsButtonPressed.emit(toggleTeamStatisticsButtonState);
           toggleTeamStatisticsButtonState = !toggleTeamStatisticsButtonState
         ">
         <div class="flex-row flex-center">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -86,7 +86,11 @@ export class AppComponent implements OverlayServiceHost {
   }
 
   showExportOverlay() {
-    this.overlayService.displayComponent(ExportOverlayComponent, {});
+    this.overlayService.displayComponent(ExportOverlayComponent, {
+      onDownloadFinished: () => {
+        this.teamService.readFromBrowserStorage(), this.overlayService.closeOverlay();
+      },
+    });
   }
 
   showPersonHighlightingOverlay() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -18,7 +18,7 @@ import { ConstraintLoggingService } from './shared/layers/business-logic-layer/c
 })
 export class AppComponent implements OverlayServiceHost {
   overlayVisible = false;
-  onTeamStatisticsButtonPressed = new EventEmitter<boolean>();
+  teamStatisticsButtonPressed = new EventEmitter<boolean>();
   toggleTeamStatisticsButtonState = true;
 
   @ViewChild(DashboardComponent)

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -27,6 +27,7 @@ import { ExportOverlayComponent } from './export-overlay/export-overlay.componen
 import { PersonDetailCardComponent } from './person-detail-card/person-detail-card.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatTabsModule } from '@angular/material/tabs';
+
 @NgModule({
   imports: [
     CommonModule,

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -27,7 +27,6 @@ import { ExportOverlayComponent } from './export-overlay/export-overlay.componen
 import { PersonDetailCardComponent } from './person-detail-card/person-detail-card.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatTabsModule } from '@angular/material/tabs';
-
 @NgModule({
   imports: [
     CommonModule,

--- a/src/app/dashboard/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard/dashboard.component.html
@@ -7,7 +7,7 @@
           class="flex-no-shrink"
           [team]="team"
           (onPersonClicked)="showPersonDetails($event)"
-          [onTeamStatisticsButtonPressed]="onTeamStatisticsButtonPressed"></app-team>
+          [teamStatisticsButtonPressed]="teamStatisticsButtonPressed"></app-team>
       </div>
     </div>
   </div>
@@ -123,6 +123,6 @@
 <!-- card that is shown if no data is loaded -->
 <ng-template #loading>
   <div class="flex-row flex-justify-center">
-    <app-intro-card (onImportPressed)="onImportPressed.emit()"></app-intro-card>
+    <app-intro-card (importPressed)="importPressed.emit()"></app-intro-card>
   </div>
 </ng-template>

--- a/src/app/dashboard/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard/dashboard.component.html
@@ -98,7 +98,7 @@
     <app-person-pool-statistics *ngIf="statisticsVisible"></app-person-pool-statistics>
 
     <!-- person preview cards -->
-    <div class="scrollable-content">
+    <div class="scrollable-content flex-grow flex-row position-relative">
       <div
         *ngIf="teamService.personsWithoutTeam.length === 0"
         class="position-absolute position-absolute-full-size pointer-events-none flex-row overflow-hidden">

--- a/src/app/dashboard/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard/dashboard.component.ts
@@ -1,8 +1,7 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { TeamService } from '../../shared/layers/business-logic-layer/team.service';
 import { DragulaService } from 'ng2-dragula';
 import { Person } from '../../shared/models/person';
-import { Team } from '../../shared/models/team';
 import { PersonDetailOverlayComponent } from '../person-detail-overlay/person-detail-overlay.component';
 import { OverlayService } from '../../overlay.service';
 import { ConstraintsOverlayComponent } from '../constraints-overlay/constraints-overlay.component';
@@ -24,8 +23,8 @@ enum PersonPoolDisplayMode {
   styleUrls: ['./dashboard.component.scss'],
 })
 export class DashboardComponent implements OnInit, OnDestroy {
-  @Output() onImportPressed = new EventEmitter();
-  @Input() onTeamStatisticsButtonPressed;
+  @Output() importPressed = new EventEmitter();
+  @Input() teamStatisticsButtonPressed;
 
   statisticsVisible = false;
 

--- a/src/app/dashboard/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { TeamService } from '../../shared/layers/business-logic-layer/team.service';
 import { DragulaService } from 'ng2-dragula';
 import { Person } from '../../shared/models/person';

--- a/src/app/dashboard/export-overlay/export-overlay.component.html
+++ b/src/app/dashboard/export-overlay/export-overlay.component.html
@@ -27,7 +27,7 @@
       <!-- lower box -->
       <div class="flex-row alternative-box">
         <mat-icon class="alternative-icon">assignment_ind</mat-icon>
-        <div class="flex-column align-items-start flex-spacing-5">
+        <div class="align-items-start flex-spacing-5">
           <div class="box-heading">Team and Person Card Images</div>
           <div class="flex-grow">
             Images of all team representations and person cards can be exported to visualize the team allocation and
@@ -35,11 +35,21 @@
           </div>
           <mat-progress-bar
             [class.progress-bar-disabled]="!imageExportRunning"
+            [class.opacity-0]="!imageExportRunning"
             mode="determinate"
             [value]="getImageExportProgressPercentage()"></mat-progress-bar>
-          <button mat-raised-button color="primary" [disabled]="imageExportRunning" (click)="exportScreenshots()">
-            <mat-icon>get_app</mat-icon>Download Archive
-          </button>
+          <div class="d-flex justify-content-between mt-3">
+            <button
+              mat-raised-button
+              color="primary"
+              [disabled]="imageExportRunning"
+              (click)="exportScreenshots(false)">
+              <mat-icon>get_app</mat-icon>Download Team Overview + Members
+            </button>
+            <button mat-raised-button color="primary" [disabled]="imageExportRunning" (click)="exportScreenshots(true)">
+              <mat-icon>get_app</mat-icon>Download Team Overview
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/dashboard/export-overlay/export-overlay.component.scss
+++ b/src/app/dashboard/export-overlay/export-overlay.component.scss
@@ -20,6 +20,7 @@
   width: 50px;
   height: 50px;
   margin-right: 20px;
+  overflow: visible;
 }
 
 .alternative-box {

--- a/src/app/dashboard/export-overlay/export-overlay.component.ts
+++ b/src/app/dashboard/export-overlay/export-overlay.component.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
+import { ApplicationRef, ChangeDetectorRef, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
 import { OverlayComponent } from '../../overlay.service';
 import { TeamService } from '../../shared/layers/business-logic-layer/team.service';
 import html2canvas from 'html2canvas';
@@ -15,7 +15,9 @@ import { Team } from '../../shared/models/team';
   styleUrls: ['./export-overlay.component.scss'],
 })
 export class ExportOverlayComponent implements OnDestroy, OverlayComponent {
-  public data: {};
+  public data: {
+    onDownloadFinished: () => void;
+  };
   destroyed = false;
   imageExportRunning = false;
   imageExportProgress = 0;
@@ -25,10 +27,10 @@ export class ExportOverlayComponent implements OnDestroy, OverlayComponent {
   @ViewChild(PersonDetailCardComponent, { read: ElementRef }) personDetailCardComponentRef: ElementRef;
 
   @ViewChild(TeamComponent) teamComponent: TeamComponent;
-  @ViewChild(TeamComponent, { read: ElementRef }) teamCompomentRef: ElementRef;
+  @ViewChild(TeamComponent, { read: ElementRef }) teamComponentRef: ElementRef;
 
   html2canvasOptions = {
-    allowTaint: false,
+    allowTaint: true,
     backgroundColor: null,
     scale: 2.0,
     useCORS: true,
@@ -37,7 +39,8 @@ export class ExportOverlayComponent implements OnDestroy, OverlayComponent {
 
   constructor(
     private teamService: TeamService,
-    private applicationRef: ApplicationRef
+    private applicationRef: ApplicationRef,
+    private readonly changeDetectorRef: ChangeDetectorRef
   ) {}
 
   ngOnDestroy() {
@@ -47,18 +50,25 @@ export class ExportOverlayComponent implements OnDestroy, OverlayComponent {
   exportCSV() {
     this.teamService.saveToLocalBrowserStorage().then(() => {
       this.teamService.exportSavedState();
+      this.data.onDownloadFinished();
     });
   }
 
-  exportScreenshots() {
+  getImageExportMaxProgress(onlyTeamOverview: boolean) {
+    return onlyTeamOverview
+      ? this.teamService.teams.reduce(acc => acc + 1, 0) + 1
+      : this.teamService.teams.reduce((acc, team) => acc + 1 + team.persons.length, 0) + 1;
+  }
+
+  exportScreenshots(onlyTeamOverview: boolean) {
     this.imageExportRunning = true;
     this.imageExportProgress = 0;
-    this.imageExportMaxProgress = this.teamService.teams.reduce((acc, team) => acc + 1 + team.persons.length, 0) + 1;
+    this.imageExportMaxProgress = this.getImageExportMaxProgress(onlyTeamOverview);
     let currentPromise = Promise.resolve();
     const zip = JSZip();
 
     this.teamService.teams.forEach(team => {
-      const teamFolder = zip.folder(team.name);
+      const teamFolder = zip.folder(onlyTeamOverview ? 'Team-Overview' : team.name);
 
       currentPromise = currentPromise.then(
         () => {
@@ -68,16 +78,18 @@ export class ExportOverlayComponent implements OnDestroy, OverlayComponent {
         () => Promise.reject(null)
       );
 
-      team.persons.forEach(
-        (person, i) =>
-          (currentPromise = currentPromise.then(
-            () => {
-              this.imageExportProgress++;
-              return this.exportPersonScreenshot(person, teamFolder, team.name + '-' + (i + 1) + '.png');
-            },
-            () => Promise.reject(null)
-          ))
-      );
+      if (!onlyTeamOverview) {
+        team.persons.forEach(
+          (person, i) =>
+            (currentPromise = currentPromise.then(
+              () => {
+                this.imageExportProgress++;
+                return this.exportPersonScreenshot(person, teamFolder, team.name + '-' + (i + 1) + '.png');
+              },
+              () => Promise.reject(null)
+            ))
+        );
+      }
     });
 
     currentPromise = currentPromise.then(
@@ -86,6 +98,7 @@ export class ExportOverlayComponent implements OnDestroy, OverlayComponent {
           FileSaver.saveAs(content, 'TEASE-image-export.zip');
           this.imageExportProgress++;
           this.imageExportRunning = false;
+          this.data.onDownloadFinished();
         }),
       () => {
         console.log('export cancelled');
@@ -105,21 +118,24 @@ export class ExportOverlayComponent implements OnDestroy, OverlayComponent {
         reject();
         return;
       }
-
       this.personDetailCardComponent.person = person;
-      this.applicationRef.tick();
+      // this.applicationRef.tick();
 
       if (this.destroyed) {
         reject();
         return;
       }
 
-      html2canvas(this.personDetailCardComponentRef.nativeElement, this.html2canvasOptions).then(canvas => {
-        canvas.toBlob(function (blob) {
-          zip.file(filename, blob);
-          resolve();
-        });
-      });
+      setTimeout(
+        () =>
+          html2canvas(this.personDetailCardComponentRef.nativeElement, this.html2canvasOptions).then(canvas => {
+            canvas.toBlob(function (blob) {
+              zip.file(filename, blob);
+              resolve();
+            });
+          }),
+        500
+      );
     });
   }
 
@@ -140,13 +156,16 @@ export class ExportOverlayComponent implements OnDestroy, OverlayComponent {
         reject();
         return;
       }
-
-      html2canvas(this.teamCompomentRef.nativeElement, this.html2canvasOptions).then(canvas => {
-        canvas.toBlob(function (blob) {
-          zip.file(filename, blob);
-          resolve();
-        });
-      });
+      setTimeout(
+        () =>
+          html2canvas(this.teamComponentRef.nativeElement, this.html2canvasOptions).then(canvas => {
+            canvas.toBlob(function (blob) {
+              zip.file(filename, blob);
+              resolve();
+            });
+          }),
+        500
+      );
     });
   }
 }

--- a/src/app/dashboard/export-overlay/export-overlay.component.ts
+++ b/src/app/dashboard/export-overlay/export-overlay.component.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, ChangeDetectorRef, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
+import { ApplicationRef, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
 import { OverlayComponent } from '../../overlay.service';
 import { TeamService } from '../../shared/layers/business-logic-layer/team.service';
 import html2canvas from 'html2canvas';
@@ -30,18 +30,14 @@ export class ExportOverlayComponent implements OnDestroy, OverlayComponent {
   @ViewChild(TeamComponent, { read: ElementRef }) teamComponentRef: ElementRef;
 
   html2canvasOptions = {
-    allowTaint: true,
+    allowTaint: false,
     backgroundColor: null,
     scale: 2.0,
     useCORS: true,
     logging: false,
   };
 
-  constructor(
-    private teamService: TeamService,
-    private applicationRef: ApplicationRef,
-    private readonly changeDetectorRef: ChangeDetectorRef
-  ) {}
+  constructor(private teamService: TeamService, private applicationRef: ApplicationRef,) {}
 
   ngOnDestroy() {
     this.destroyed = true;
@@ -119,7 +115,6 @@ export class ExportOverlayComponent implements OnDestroy, OverlayComponent {
         return;
       }
       this.personDetailCardComponent.person = person;
-      // this.applicationRef.tick();
 
       if (this.destroyed) {
         reject();

--- a/src/app/dashboard/export-overlay/export-overlay.component.ts
+++ b/src/app/dashboard/export-overlay/export-overlay.component.ts
@@ -142,10 +142,9 @@ export class ExportOverlayComponent implements OnDestroy, OverlayComponent {
         return;
       }
 
+      this.teamComponent.team = team;
       this.teamComponent.screenshotMode = true;
       this.teamComponent.statisticsVisible = true;
-      this.teamComponent.team = team;
-      this.applicationRef.tick();
 
       if (this.destroyed) {
         reject();

--- a/src/app/dashboard/intro-card/intro-card.component.html
+++ b/src/app/dashboard/intro-card/intro-card.component.html
@@ -2,7 +2,7 @@
   <div class="heading">Welcome to TEASE!</div>
   <div class="text-row flex-row flex-center">
     <div class="text">To get started, press</div>
-    <button mat-raised-button color="primary" (click)="onImportPressed.emit()">
+    <button mat-raised-button color="primary" (click)="importPressed.emit()">
       <div class="flex-row flex-center">
         <mat-icon class="material-icon-trailing-space">file_upload</mat-icon>
         <div>Import</div>

--- a/src/app/dashboard/intro-card/intro-card.component.ts
+++ b/src/app/dashboard/intro-card/intro-card.component.ts
@@ -6,5 +6,5 @@ import { Component, EventEmitter, Output } from '@angular/core';
   styleUrls: ['./intro-card.component.scss'],
 })
 export class IntroCardComponent {
-  @Output() onImportPressed = new EventEmitter();
+  @Output() importPressed = new EventEmitter();
 }

--- a/src/app/dashboard/person-detail-card/person-detail-card.component.html
+++ b/src/app/dashboard/person-detail-card/person-detail-card.component.html
@@ -2,7 +2,7 @@
   <!-- profile picture and everything right to it -->
   <div class="flex-row overflow-hidden">
     <div class="profile-picture">
-      <img src="{{ getGravatarIcon(person.email, 400) }}" />
+      <img id="gravatar" src="{{ person.gravatarUrl }}" />
     </div>
 
     <!-- column right to the profile picture -->

--- a/src/app/dashboard/person-detail-card/person-detail-card.component.html
+++ b/src/app/dashboard/person-detail-card/person-detail-card.component.html
@@ -2,7 +2,7 @@
   <!-- profile picture and everything right to it -->
   <div class="flex-row overflow-hidden">
     <div class="profile-picture">
-      <img id="gravatar" src="{{ person.gravatarUrl }}" />
+      <img src="{{ person.gravatarUrl }}" />
     </div>
 
     <!-- column right to the profile picture -->

--- a/src/app/dashboard/person-detail-card/person-detail-card.component.ts
+++ b/src/app/dashboard/person-detail-card/person-detail-card.component.ts
@@ -16,7 +16,6 @@ export class PersonDetailCardComponent {
   @Input() person: Person;
 
   getLabelForSkillLevel = Skill.getLabelForSkillLevel;
-  getGravatarIcon = IconMapperService.getGravatarIcon;
   SkillLevel = SkillLevel;
   CSVConstants = CSVConstants;
   Device = Device;

--- a/src/app/dashboard/person-preview/person-preview.component.html
+++ b/src/app/dashboard/person-preview/person-preview.component.html
@@ -6,7 +6,7 @@
     <!-- profile pic and everything right to it -->
     <div class="flex-row">
       <div class="profile-pic">
-        <img src="{{ getGravatarIcon(this.person.email, 180) }}" />
+        <img src="{{ person.gravatarUrl }}" />
       </div>
 
       <!-- column with personal information right to the profile picture -->

--- a/src/app/dashboard/person-preview/person-preview.component.ts
+++ b/src/app/dashboard/person-preview/person-preview.component.ts
@@ -17,6 +17,7 @@ export class PersonPreviewComponent implements OnInit {
   @Input() person: Person;
   @Input() pinable = true;
 
+  gravatarUrl: string = '';
   SkillLevel = SkillLevel;
   Device = Device;
   PersonConstraintService = PersonConstraintService;

--- a/src/app/dashboard/person-preview/person-preview.component.ts
+++ b/src/app/dashboard/person-preview/person-preview.component.ts
@@ -17,14 +17,13 @@ export class PersonPreviewComponent implements OnInit {
   @Input() person: Person;
   @Input() pinable = true;
 
-  gravatarUrl: string = '';
   SkillLevel = SkillLevel;
   Device = Device;
   PersonConstraintService = PersonConstraintService;
   getFlagEmojiFromNationality = NationalityHelper.getFlagEmojiFromNationality;
 
   /* functions used in template */
-  protected getGravatarIcon = IconMapperService.getGravatarIcon;
+
   protected getGenderIconPath = IconMapperService.getGenderIconPath;
   protected getColor = Colors.getColor;
   protected getLabelForSkillLevel = Skill.getLabelForSkillLevel;

--- a/src/app/dashboard/team-priorities-chart/team-priorities-chart.component.ts
+++ b/src/app/dashboard/team-priorities-chart/team-priorities-chart.component.ts
@@ -1,6 +1,5 @@
-import { Component, DoCheck, Input, OnInit } from '@angular/core';
+import { Component, DoCheck, Input, OnChanges, OnInit } from '@angular/core';
 import { Team } from '../../shared/models/team';
-import { PersonStatisticsService } from '../../shared/layers/business-logic-layer/person-statistics.service';
 import { Colors } from '../../shared/constants/color.constants';
 import { SkillLevel } from '../../shared/models/skill';
 import { TeamService } from '../../shared/layers/business-logic-layer/team.service';
@@ -10,7 +9,7 @@ import { TeamService } from '../../shared/layers/business-logic-layer/team.servi
   templateUrl: './team-priorities-chart.component.html',
   styleUrls: ['./team-priorities-chart.component.scss'],
 })
-export class TeamPrioritiesChartComponent implements OnInit, DoCheck {
+export class TeamPrioritiesChartComponent implements OnInit, DoCheck, OnChanges {
   @Input() team: Team;
   @Input() scale;
 
@@ -22,6 +21,10 @@ export class TeamPrioritiesChartComponent implements OnInit, DoCheck {
   constructor(private teamService: TeamService) {}
 
   ngOnInit(): void {
+    this.updatePriorityDistribution();
+  }
+
+  ngOnChanges(): void {
     this.updatePriorityDistribution();
   }
 

--- a/src/app/dashboard/team/team.component.ts
+++ b/src/app/dashboard/team/team.component.ts
@@ -9,7 +9,7 @@ import { Person } from '../../shared/models/person';
 })
 export class TeamComponent implements OnInit {
   @Input() team: Team;
-  @Input() onTeamStatisticsButtonPressed;
+  @Input() teamStatisticsButtonPressed;
   @Output() onPersonClicked = new EventEmitter<Person>();
 
   @Input() 
@@ -20,7 +20,7 @@ export class TeamComponent implements OnInit {
   statisticsVisible = false;
 
   ngOnInit() {
-    if (this.onTeamStatisticsButtonPressed)
-      this.onTeamStatisticsButtonPressed.subscribe(showStatistics => (this.statisticsVisible = showStatistics));
+    if (this.teamStatisticsButtonPressed)
+      this.teamStatisticsButtonPressed.subscribe(showStatistics => (this.statisticsVisible = showStatistics));
   }
 }

--- a/src/app/shared/layers/data-access-layer/PersonParser.ts
+++ b/src/app/shared/layers/data-access-layer/PersonParser.ts
@@ -4,6 +4,7 @@ import { Device } from '../../models/device';
 import { StringHelper } from '../../helpers/string.helper';
 import { Skill, SkillLevel } from '../../models/skill';
 import { Team } from '../../models/team';
+import { IconMapperService } from '../../ui/icon-mapper.service';
 /**
  * Created by Malte Bucksch on 01/12/2016.
  */
@@ -86,6 +87,8 @@ export abstract class PersonParser {
       const teamIndex = teams.findIndex(team => team.name === person.teamName);
       if (teamIndex !== -1) teams[teamIndex].persons.push(person);
     }
+
+    person.gravatarUrl = IconMapperService.getGravatarIcon(personProps[CSVConstants.Person.Email]);
 
     return person;
   }

--- a/src/app/shared/models/person.ts
+++ b/src/app/shared/models/person.ts
@@ -22,6 +22,7 @@ export class Person {
   nationality: string;
   major: string;
   semester: number;
+  gravatarUrl?: string;
 
   germanLanguageLevel: string;
   englishLanguageLevel: string;

--- a/src/app/shared/ui/icon-mapper.service.ts
+++ b/src/app/shared/ui/icon-mapper.service.ts
@@ -52,8 +52,7 @@ export class IconMapperService {
   }
 
   static getGravatarIcon(email: string, size = 200): string {
-    if (email === undefined) return IconMapperService.GRAVATAR_URL;
-
+    if (!email) return IconMapperService.GRAVATAR_URL;
     const emailHash = MD5(email).toString();
     return IconMapperService.GRAVATAR_URL + emailHash + '?s=' + size.toString() + '&d=mm';
   }


### PR DESCRIPTION
This PR solves the issue that a gravatar was mapped to the wrong student. It also fixes another drag and drop error after exporting images. 
I also added an additional button to download only the team overview. This saves some time in case the team member images are not needed. 

Test steps: Start TEASE, import data and check if the images are exported correctly (especially gravatar and statistics). 